### PR TITLE
The flags section was too greedy.

### DIFF
--- a/src/Requirement.php
+++ b/src/Requirement.php
@@ -19,8 +19,11 @@ class Requirement
 
         $next = trim($line);
 
+        // Regex: Split on any whitespace
         list($id, $next) = preg_split('/\s+/', $next, 2);
 
+        // Regex: Id must be 1 or more numeric characters, followed by any 
+        // number of alphabetic or dot characters, followed by exactly one dot
         if (preg_match('/^\d+[a-z\.]*\.$/i', $id)) {
             $this->id = $id;
         } else {
@@ -29,7 +32,9 @@ class Requirement
             return;
         }
 
-        if (preg_match('/^\((.*)\)/', $next, $flags)) {
+        // Regex: Matches parentheses with nothing or anything inside them
+        // unless what's inside them is a right-parenthesis.
+        if (preg_match('/^\(([^\)]*)\)/', $next, $flags)) {
             $this->flags = preg_split('/\s*,\s*/', $flags[1]);
             $next = trim(substr($next, strlen($flags[0])));
         } else {

--- a/tests/RequirementTest.php
+++ b/tests/RequirementTest.php
@@ -25,10 +25,13 @@ class RequirementTest extends TestCase
 
     public function testHasFlag()
     {
-        $requirement = new Requirement('2.a.a. (A,B) System MUST NOT catch fire.');
+        $requirement = new Requirement('2.a.a. (A,B) System MUST NOT (ever) catch fire.');
         $this->assertTrue($requirement->hasFlag('A'));
         $this->assertTrue($requirement->hasFlag('B'));
         $this->assertFalse($requirement->hasFlag('C'));
+
+        $requirement = new Requirement('2.a.a. System MUST NOT (ever) catch fire.');
+        $this->assertFalse($requirement->hasFlag('ever'));
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/lower-speck/lower-speck-php/issues/1

If a requirement has flags, and also has parens in the requirement text, don't mistake those for each other.